### PR TITLE
ant: add JSON scraper

### DIFF
--- a/_examples/jsonquotes/main.go
+++ b/_examples/jsonquotes/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"time"
+
+	"github.com/yields/ant"
+)
+
+type quote struct {
+	Text string   `css:".text"   json:"text"`
+	By   string   `css:".author" json:"by"`
+	Tags []string `css:".tag"    json:"tags"`
+}
+
+type page struct {
+	Quotes []quote `css:".quote" json:"quotes"`
+}
+
+func main() {
+	var url = "http://quotes.toscrape.com"
+	var ctx = context.Background()
+	var start = time.Now()
+
+	eng, err := ant.NewEngine(ant.EngineConfig{
+		Scraper: ant.JSON(os.Stdout, page{}, `li.next > a`),
+		Matcher: ant.MatchHostname("quotes.toscrape.com"),
+	})
+	if err != nil {
+		log.Fatalf("new engine: %s", err)
+	}
+
+	if err := eng.Run(ctx, url); err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("scraped in %s :)", time.Since(start))
+}

--- a/_examples/quotes/main.go
+++ b/_examples/quotes/main.go
@@ -40,7 +40,8 @@ func (s *scraper) Scrape(ctx context.Context, p *ant.Page) (ant.URLs, error) {
 
 	atomic.AddUint64(&s.quotes, uint64(len(items.Quotes)))
 	atomic.AddUint64(&s.pages, 1)
-	return p.URLs(), nil
+
+	return p.Next(`li.next > a`)
 }
 
 func main() {

--- a/ant.go
+++ b/ant.go
@@ -3,9 +3,13 @@ package ant
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
+	"reflect"
 	"time"
 )
 
@@ -26,6 +30,71 @@ type Scraper interface {
 	// a `Temporary() bool` method that returns true it will
 	// be retried.
 	Scrape(ctx context.Context, p *Page) (URLs, error)
+}
+
+// JSON returns a new JSON scraper.
+//
+// The scraper receives the writer to write JSON lines into
+// the type to scrape from pages and optional selectors from
+// which to extract the next set of pages to crawl.
+//
+// The provided type `t` must be a struct, otherwise the scraper
+// will return an error on the initial scrape and the crawl engine
+// will abort.
+//
+// The scraper uses the `encoding/json` package to encode the provided
+// type into JSON, any errors that are received from the encoder are
+// returned from the scraper.
+//
+// If no selectors are provided, the scraper will return all valid
+// URLs on the page.
+func JSON(w io.Writer, t interface{}, selectors ...string) Scraper {
+	var typ = reflect.TypeOf(t)
+	var enc = json.NewEncoder(w)
+
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+
+	return &jsonscraper{
+		typ:       typ,
+		enc:       enc,
+		selectors: selectors,
+	}
+}
+
+// Jsonscraper implements a json scraper.
+type jsonscraper struct {
+	typ       reflect.Type
+	enc       *json.Encoder
+	selectors []string
+}
+
+// Scrape implementation.
+func (j *jsonscraper) Scrape(ctx context.Context, p *Page) (URLs, error) {
+	var v = reflect.New(j.typ)
+
+	if err := p.Scan(v.Interface()); err != nil {
+		return nil, err
+	}
+
+	if err := j.enc.Encode(v.Interface()); err != nil {
+		return nil, fmt.Errorf("ant: json encode %s - %w", j.typ, err)
+	}
+
+	if len(j.selectors) > 0 {
+		var next URLs
+		for _, sel := range j.selectors {
+			urls, err := p.Next(sel)
+			if err != nil {
+				return nil, err
+			}
+			next = append(next, urls...)
+		}
+		return next, nil
+	}
+
+	return p.URLs(), nil
 }
 
 // Client represents an HTTP client.


### PR DESCRIPTION
Just a simple scraper that should handle 99% of scraping needs:

```go
type quote struct {
  Text string   `css:".text"   json:"text"`
  By   string   `css:".author" json:"by"`
  Tags []string `css:".tag"    json:"tags"`
}

type page struct {
  Quotes []quote `css:".quote" json:"quotes"`
}

eng, err := ant.NewEngine(ant.EngineConfig{
  Scraper: ant.JSON(os.Stdout, page{}, `li.next > a`),
})

eng.Run(ctx)
```
