### PR TITLE
add antcache

### DIFF
--- a/_examples/cache/main.go
+++ b/_examples/cache/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"time"
+
+	"github.com/yields/ant"
+	"github.com/yields/ant/antcache"
+)
+
+type quote struct {
+	Text string   `css:".text"   json:"text"`
+	By   string   `css:".author" json:"by"`
+	Tags []string `css:".tag"    json:"tags"`
+}
+
+type page struct {
+	Quotes []quote `css:".quote" json:"quotes"`
+}
+
+func main() {
+	var url = "http://quotes.toscrape.com"
+	var ctx = context.Background()
+	var start = time.Now()
+
+	disk, err := antcache.Open("/tmp")
+	if err != nil {
+		log.Printf("open disk: %s", err)
+	}
+
+	if err := disk.Wait(ctx); err != nil {
+		log.Printf("disk wait: %s", err)
+	}
+
+	client, err := antcache.New(
+		ant.DefaultClient,
+		antcache.Aggressive(24*time.Hour),
+		antcache.WithStorage(disk),
+	)
+	if err != nil {
+		log.Printf("new cache: %s", err)
+	}
+
+	eng, err := ant.NewEngine(ant.EngineConfig{
+		Scraper: ant.JSON(os.Stdout, page{}, `li.next > a`),
+		Matcher: ant.MatchHostname("quotes.toscrape.com"),
+		Fetcher: &ant.Fetcher{
+			Client: client,
+		},
+	})
+	if err != nil {
+		log.Fatalf("new engine: %s", err)
+	}
+
+	if err := eng.Run(ctx, url); err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("scraped in %s :)", time.Since(start))
+}

--- a/antcache/aggressive.go
+++ b/antcache/aggressive.go
@@ -1,0 +1,84 @@
+package antcache
+
+import (
+	"net/http"
+	"time"
+)
+
+// Aggressive returns an aggressive cache with age.
+//
+// Unlike the default RFC7234 cache, this caching strategy
+// will cache all GET/HEAD requests unless they specify
+// a Range/Content-Range headers, the Authorization header
+// and the "no-store" cache directive.
+//
+// This makes the aggressive cache arguably better for crawling
+// since it can cache responses up to a specific age but still
+// allows you to bypass the cache if you set the "no-cache" directive.
+//
+// The cacher will also ignore any "no-cache" and "no-store" or other
+// directives from the response, since some websites never implement
+// proper caching.
+//
+// When age <= 0, the default of 24 hours is used.
+func Aggressive(age time.Duration) Option {
+	return func(c *Cache) error {
+		c.strategy = aggressive{age}
+		return nil
+	}
+}
+
+// Aggressive implements aggressive cache.
+type aggressive struct {
+	age time.Duration
+}
+
+// Cache implementation.
+func (a aggressive) cache(req *http.Request) bool {
+	return rfc7234{}.cache(req)
+}
+
+// Store implementation.
+func (a aggressive) store(resp *http.Response) bool {
+	var req = resp.Request
+
+	// The request method is cacheable.
+	switch req.Method {
+	case "GET":
+	case "HEAD":
+	default:
+		return false
+	}
+
+	// The response status code is cacheable.
+	switch resp.StatusCode {
+	case 200, 203, 204, 206:
+	case 300, 301:
+	case 404, 405, 410, 414:
+	case 501:
+	default:
+		return false
+	}
+
+	// The response has a date header.
+	_, ok := date(resp.Header)
+	return ok
+}
+
+// Fresh implementation.
+func (a aggressive) fresh(resp *http.Response) freshness {
+	if date, ok := date(resp.Header); ok {
+		if time.Since(date) < a.lifetime() {
+			return fresh
+		}
+	}
+	return transparent
+}
+
+// Lifetime returns the lifetime.
+func (a aggressive) lifetime() time.Duration {
+	if a.age > 0 {
+		return a.age
+	}
+	return 24 * time.Hour
+}

--- a/antcache/aggressive_test.go
+++ b/antcache/aggressive_test.go
@@ -1,0 +1,142 @@
+package antcache
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAggressive(t *testing.T) {
+	t.Run("store", func(t *testing.T) {
+		var now = time.Now().UTC()
+		var cases = []struct {
+			title string
+			resp  *http.Response
+			store bool
+		}{
+			{
+				title: "GET",
+				resp: &http.Response{
+					StatusCode: 200,
+					Header: http.Header{
+						"Date": {now.Format(time.RFC1123)},
+					},
+					Request: &http.Request{
+						Method: "GET",
+					},
+				},
+				store: true,
+			},
+			{
+				title: "HEAD",
+				resp: &http.Response{
+					StatusCode: 200,
+					Header: http.Header{
+						"Date": {now.Format(time.RFC1123)},
+					},
+					Request: &http.Request{
+						Method: "HEAD",
+					},
+				},
+				store: true,
+			},
+			{
+				title: "no date header",
+				resp: &http.Response{
+					StatusCode: 200,
+					Request: &http.Request{
+						Method: "HEAD",
+					},
+				},
+				store: false,
+			},
+			{
+				title: "POST",
+				resp: &http.Response{
+					StatusCode: 200,
+					Request: &http.Request{
+						Method: "POST",
+					},
+				},
+				store: false,
+			},
+			{
+				title: "GET 500",
+				resp: &http.Response{
+					StatusCode: 500,
+					Request: &http.Request{
+						Method: "GET",
+					},
+				},
+				store: false,
+			},
+		}
+
+		for _, c := range cases {
+			t.Run(c.title, func(t *testing.T) {
+				var assert = require.New(t)
+				var strategy = aggressive{}
+
+				assert.Equal(c.store, strategy.store(c.resp))
+			})
+		}
+	})
+
+	t.Run("fresh", func(t *testing.T) {
+		var now = time.Now()
+		var cases = []struct {
+			title string
+			resp  *http.Response
+			fresh freshness
+		}{
+			{
+				title: "fresh",
+				resp: &http.Response{
+					Request: &http.Request{},
+					Header: http.Header{
+						"Date": {now.Format(time.RFC1123)},
+					},
+				},
+				fresh: fresh,
+			},
+			{
+				title: "fresh 2 hours",
+				resp: &http.Response{
+					Request: &http.Request{},
+					Header: http.Header{
+						"Date": {now.Add(-(2 * time.Hour)).Format(time.RFC1123)},
+					},
+				},
+				fresh: fresh,
+			},
+			{
+				title: "transparent 2 days",
+				resp: &http.Response{
+					Request: &http.Request{},
+					Header: http.Header{
+						"Date": {now.Add(-(48 * time.Hour)).Format(time.RFC1123)},
+					},
+				},
+				fresh: transparent,
+			},
+			{
+				title: "transparent",
+				resp: &http.Response{
+					Request: &http.Request{},
+				},
+				fresh: transparent,
+			},
+		}
+
+		for _, c := range cases {
+			t.Run(c.title, func(t *testing.T) {
+				var assert = require.New(t)
+				var strategy = aggressive{}
+
+				assert.Equal(c.fresh, strategy.fresh(c.resp))
+			})
+		}
+	})
+}

--- a/antcache/cachereader.go
+++ b/antcache/cachereader.go
@@ -1,0 +1,53 @@
+package antcache
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httputil"
+	"sync"
+)
+
+// Cachereader is a special reader that caches
+// a response when it is closed.
+type cachereader struct {
+	resp  *http.Response
+	key   uint64
+	rc    io.ReadCloser
+	buf   *bytes.Buffer
+	once  *sync.Once
+	ctx   context.Context
+	store func(ctx context.Context, key uint64, v []byte) error
+	log   func(msg string, args ...interface{})
+}
+
+// Read implementation.
+func (cr *cachereader) Read(p []byte) (n int, err error) {
+	n, err = cr.rc.Read(p)
+	cr.buf.Write(p)
+	return n, err
+}
+
+// Close implementation.
+func (cr *cachereader) Close() error {
+	err := cr.rc.Close()
+
+	cr.once.Do(func() {
+		resp := *cr.resp
+		resp.Body = ioutil.NopCloser(cr.buf)
+
+		buf, err := httputil.DumpResponse(&resp, true)
+		if err != nil {
+			cr.log("antcache: dump response - %s", err)
+			return
+		}
+
+		if err := cr.store(cr.ctx, cr.key, buf); err != nil {
+			cr.log("antcache: store response - %s", err)
+		}
+	})
+
+	return err
+}

--- a/antcache/directives.go
+++ b/antcache/directives.go
@@ -1,0 +1,48 @@
+package antcache
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Directives represents cache-control directives.
+type directives map[string]string
+
+// DirectivesFrom returns directives from h.
+func directivesFrom(h http.Header) directives {
+	var c = h.Get("Cache-Control")
+	var d directives
+
+	for _, item := range split(c, ",") {
+		if d == nil {
+			d = make(directives)
+		}
+
+		if j := strings.IndexByte(item, '='); j != -1 {
+			d[item[:j]] = item[j+1:]
+		} else {
+			d[item] = ""
+		}
+	}
+
+	return d
+}
+
+// Has returns true if directive name is set.
+func (d directives) has(name string) bool {
+	_, ok := d[name]
+	return ok
+}
+
+// Duration parses directive duration by name.
+//
+// Ok is true if the directive exists and has a positive duration.
+func (d directives) duration(name string) (td time.Duration, ok bool) {
+	if v, has := d[name]; has {
+		n, err := strconv.ParseInt(v, 10, 64)
+		td, ok = (time.Duration(n) * time.Second), err == nil
+	}
+	return
+}

--- a/antcache/directives_test.go
+++ b/antcache/directives_test.go
@@ -1,0 +1,126 @@
+package antcache
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirectives(t *testing.T) {
+	t.Run("has", func(t *testing.T) {
+		var cases = []struct {
+			title   string
+			headers http.Header
+			name    string
+			has     bool
+		}{
+			{
+				title:   "nil headers",
+				headers: nil,
+				name:    "no-cache",
+				has:     false,
+			},
+			{
+				title: "exists",
+				headers: http.Header{
+					"Cache-Control": []string{"no-cache"},
+				},
+				name: "no-cache",
+				has:  true,
+			},
+			{
+				title: "case insensitive",
+				headers: http.Header{
+					"Cache-Control": []string{"No-Cache"},
+				},
+				name: "no-cache",
+				has:  true,
+			},
+			{
+				title: "missing",
+				headers: http.Header{
+					"Cache-Control": []string{"max-age=5,must-revalidate"},
+				},
+				name: "no-cache",
+				has:  false,
+			},
+		}
+
+		for _, c := range cases {
+			t.Run(c.title, func(t *testing.T) {
+				var assert = require.New(t)
+				var d = directivesFrom(c.headers)
+
+				assert.Equal(c.has, d.has(c.name))
+			})
+		}
+	})
+
+	t.Run("duration", func(t *testing.T) {
+		var cases = []struct {
+			title    string
+			headers  http.Header
+			name     string
+			duration time.Duration
+			ok       bool
+		}{
+			{
+				title:    "nil headers",
+				headers:  nil,
+				name:     "max-age",
+				duration: 0,
+				ok:       false,
+			},
+			{
+				title: "max-age",
+				headers: http.Header{
+					"Cache-Control": []string{"max-age=5"},
+				},
+				name:     "max-age",
+				duration: 5 * time.Second,
+				ok:       true,
+			},
+			{
+				title: "negative max-age",
+				headers: http.Header{
+					"Cache-Control": []string{"max-age=-5"},
+				},
+				name:     "max-age",
+				duration: -(5 * time.Second),
+				ok:       true,
+			},
+			{
+				title: "zero max-age",
+				headers: http.Header{
+					"Cache-Control": []string{"max-age=0"},
+				},
+				name:     "max-age",
+				duration: 0,
+				ok:       true,
+			},
+			{
+				title: "invalid max-age",
+				headers: http.Header{
+					"Cache-Control": []string{"max-age=n"},
+				},
+				name:     "max-age",
+				duration: 0,
+				ok:       false,
+			},
+		}
+
+		for _, c := range cases {
+			t.Run(c.title, func(t *testing.T) {
+				var assert = require.New(t)
+				var d = directivesFrom(c.headers)
+
+				dur, ok := d.duration(c.name)
+
+				assert.Equal(c.ok, ok)
+				assert.Equal(c.duration, dur)
+			})
+		}
+	})
+}

--- a/antcache/disk.go
+++ b/antcache/disk.go
@@ -1,0 +1,380 @@
+package antcache
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/go-errors/errors"
+)
+
+// File represents an in-memory file.
+type file struct {
+	key   uint64
+	path  string
+	mtime time.Time
+	size  int64
+}
+
+// DiskOption represents a disk option.
+type DiskOption func(*Diskstore) error
+
+// Maxage sets the maxage to age.
+//
+// When <= 0, the disk will not spawn a goroutine
+// that will cleanup older files.
+func Maxage(age time.Duration) DiskOption {
+	return func(d *Diskstore) error {
+		d.maxage = age
+		return nil
+	}
+}
+
+// Maxsize sets the maxsize to size.
+//
+// When <= 0, the disk will not spawn a goroutine
+// that will remove older files when the directory
+// reaches the given size.
+func Maxsize(size int64) DiskOption {
+	return func(d *Diskstore) error {
+		d.maxsize = size
+		return nil
+	}
+}
+
+// Diskstore implements disk cache storage.
+//
+// The storage is expected to be configured with
+// an existing directory `path` where it will write
+// all cached responses.
+//
+// The storage ensures that store calls are not visible
+// to load calls until the file is written to disk successfully
+// and fsynced, it does this by writing a temporary file, fsyncing it
+// and then renaming it to the expected filename.
+//
+// When the disk is configured with invalid directory name
+// all its method return the same error.
+type Diskstore struct {
+	path    string
+	dir     *os.File
+	maxage  time.Duration
+	maxsize int64
+	stop    chan struct{}
+	warm    chan struct{}
+	wg      sync.WaitGroup
+	readymu sync.RWMutex
+	ready   map[uint64]file
+}
+
+// Open opens a new disk storage.
+//
+// It is up to the caller to ensure that the given path will
+// not be changed by different processes, the diskstore doesn't
+// implement any filesystem level locking.
+func Open(path string, opts ...DiskOption) (*Diskstore, error) {
+	disk := &Diskstore{
+		path:    path,
+		maxage:  24 * time.Hour,
+		maxsize: 1 << 30,
+		stop:    make(chan struct{}),
+		wg:      sync.WaitGroup{},
+		warm:    make(chan struct{}),
+		readymu: sync.RWMutex{},
+		ready:   make(map[uint64]file),
+	}
+
+	for _, opt := range opts {
+		if err := opt(disk); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := disk.init(); err != nil {
+		return nil, err
+	}
+
+	disk.wg.Add(2)
+	go disk.warmup()
+	go disk.sweeper()
+
+	return disk, nil
+}
+
+// Init initializes the disk store.
+func (d *Diskstore) init() error {
+	if !filepath.IsAbs(d.path) {
+		return fmt.Errorf("antcache: disk expects an absolute path, got %q", d.path)
+	}
+
+	f, err := os.Open(d.path)
+	if err != nil {
+		return fmt.Errorf("antcache: disk open %q - %w", d.path, err)
+	}
+
+	stat, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return fmt.Errorf("antcache: disk stat %q - %w", d.path, err)
+	}
+
+	if !stat.IsDir() {
+		f.Close()
+		return fmt.Errorf("antcache: disk exepcted a directory")
+	}
+
+	d.dir = f
+	return nil
+}
+
+// Wait waits for the disk to read all files.
+//
+// When the disk is initialized it will spawn a goroutine
+// to read all files in the configured path, if there are many
+// files it will typically take a while.
+//
+// The method returns the context's error if canceled, otherwise
+// it will block until the disk cache is warm.
+func (d *Diskstore) Wait(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-d.warm:
+		return nil
+	}
+}
+
+// Warmup ensures that all on disk files are referenced in-memory.
+//
+// The method loops over all files in the configured directory and
+// attempts to add them into the .ready map to be used by `Load()`.
+//
+// The method logs if any errors occur.
+func (d *Diskstore) warmup() {
+	var files []file
+
+	defer func() {
+		close(d.warm)
+		d.wg.Done()
+	}()
+
+	for {
+		names, err := d.dir.Readdirnames(5)
+
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		for _, name := range names {
+			var path = filepath.Join(d.path, name)
+
+			if filepath.Ext(path) == "tmp" {
+				continue
+			}
+
+			n, err := strconv.ParseUint(name, 10, 64)
+			if err != nil {
+				log.Printf("antcache: disk cache invalid entry - %s", name)
+				continue
+			}
+
+			stat, err := os.Stat(path)
+			if err != nil {
+				log.Printf("antcache: disk stat %s - %s", path, err)
+				continue
+			}
+
+			files = append(files, file{
+				key:   n,
+				path:  path,
+				size:  stat.Size(),
+				mtime: stat.ModTime(),
+			})
+		}
+	}
+
+	d.readymu.Lock()
+	for _, f := range files {
+		if _, ok := d.ready[f.key]; !ok {
+			d.ready[f.key] = f
+		}
+	}
+	d.readymu.Unlock()
+}
+
+// Sweeper sweeps the directory.
+//
+// Every minute, the sweeper will wake and loop over all
+// "ready" files, if any of the items maxage exceeds that of
+// the configured maxage, the method will acquire a lock
+// and delete the file.
+//
+// If the size of all items exceeds the configured maxsize
+// the method will delete old files until the maxsize is reached.
+func (d *Diskstore) sweeper() {
+	var t = time.NewTicker(5 * time.Minute)
+
+	defer func() {
+		t.Stop()
+		d.wg.Done()
+	}()
+
+	for {
+		select {
+		case <-d.stop:
+			return
+
+		case <-t.C:
+			if _, err := d.sweep(); err != nil {
+				log.Printf("antcache: disk sweep - %s", err)
+			}
+		}
+	}
+}
+
+// Sweep sweeps the directory.
+func (d *Diskstore) sweep() (int, error) {
+	var files = d.files()
+	var removed int
+	var remove []file
+	var sum int64
+
+	sort.Slice(files, func(i, j int) bool {
+		a := files[i].mtime
+		b := files[j].mtime
+		return a.Before(b)
+	})
+
+	for _, f := range files {
+		if d.maxage > 0 {
+			remove = append(remove, f)
+		}
+
+		if d.maxsize > 0 {
+			if sum += f.size; sum > d.maxsize {
+				remove = append(remove, f)
+			}
+		}
+	}
+
+	d.readymu.Lock()
+	defer d.readymu.Unlock()
+
+	for _, f := range files {
+		if _, ok := d.ready[f.key]; ok {
+			if err := os.Remove(f.path); err != nil {
+				log.Printf("antcache: disk remove - %s", err)
+				continue
+			}
+			delete(d.ready, f.key)
+			removed++
+		}
+	}
+
+	return removed, nil
+}
+
+// Files returns the files.
+func (d *Diskstore) files() []file {
+	d.readymu.RLock()
+	ret := make([]file, 0, len(d.ready))
+	for _, f := range d.ready {
+		ret = append(ret, f)
+	}
+	d.readymu.RUnlock()
+	return ret
+}
+
+// Store implementation.
+func (d *Diskstore) Store(ctx context.Context, key uint64, v []byte) error {
+	f, err := ioutil.TempFile(d.path, "*.tmp")
+	if err != nil {
+		return fmt.Errorf("antcache: open tempfile - %w", err)
+	}
+
+	cleanup := func() {
+		f.Close()
+		os.Remove(f.Name())
+	}
+
+	if _, err := f.Write(v); err != nil {
+		cleanup()
+		return fmt.Errorf("antcache: disk write - %w", err)
+	}
+
+	if err := f.Sync(); err != nil {
+		cleanup()
+		return fmt.Errorf("antcache: disk fsync - %w", err)
+	}
+
+	if err := d.add(key, f); err != nil {
+		cleanup()
+		return fmt.Errorf("antcache: add - %w", err)
+	}
+
+	return nil
+}
+
+// Load implementation.
+func (d *Diskstore) Load(_ context.Context, key uint64) (v []byte, err error) {
+	d.readymu.RLock()
+	defer d.readymu.RUnlock()
+
+	if f, ok := d.ready[key]; ok {
+		if v, err = ioutil.ReadFile(f.path); err != nil {
+			err = fmt.Errorf("antcache: disk read %q - %w", f.path, err)
+		}
+	}
+
+	return
+}
+
+// Add adds the given file to the keys cache.
+func (d *Diskstore) add(key uint64, f *os.File) error {
+	var newname = strconv.FormatUint(key, 10)
+	var newpath = filepath.Join(d.path, newname)
+
+	stat, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("antcache: disk stat - %w", err)
+	}
+
+	if err := os.Rename(f.Name(), newpath); err != nil {
+		return fmt.Errorf("antcache: disk rename - %w", err)
+	}
+
+	if err := d.dir.Sync(); err != nil {
+		return fmt.Errorf("antcache: disk fsync - %w", err)
+	}
+
+	d.readymu.Lock()
+	d.ready[key] = file{
+		key:   key,
+		path:  newpath,
+		size:  stat.Size(),
+		mtime: stat.ModTime(),
+	}
+	d.readymu.Unlock()
+
+	return nil
+}
+
+// Close closes the diskstore.
+func (d *Diskstore) Close() error {
+	close(d.stop)
+	d.wg.Wait()
+
+	if err := d.dir.Close(); err != nil {
+		return fmt.Errorf("antcache: disk close dir - %w", err)
+	}
+
+	return nil
+}

--- a/antcache/disk_test.go
+++ b/antcache/disk_test.go
@@ -1,0 +1,5 @@
+package antcache
+
+import "testing"
+
+func TestDiskstore(t *testing.T) {}

--- a/antcache/httpcache.go
+++ b/antcache/httpcache.go
@@ -1,0 +1,280 @@
+// Package antcache implements an HTTP client that caches responses.
+package antcache
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+)
+
+// Freshness enumerates freshness.
+type freshness int
+
+// String implementation.
+func (f freshness) String() string {
+	switch f {
+	case fresh:
+		return "fresh"
+	case stale:
+		return "stale"
+	case transparent:
+		return "transprent"
+	default:
+		return fmt.Sprintf("antcache.freshness(%d)", f)
+	}
+}
+
+// All freshness types.
+const (
+	fresh freshness = iota
+	stale
+	transparent
+)
+
+// Strategy represents a cache strategy.
+type strategy interface {
+	// Cache returns true if the request is cacheable.
+	//
+	// The method is called just before a the storage lookup
+	// is made.
+	cache(req *http.Request) bool
+
+	// Store returns true if the response can be stored.
+	//
+	// The method is called just before a response is stored.
+	store(resp *http.Response) bool
+
+	// Fresh returns true if the response is fresh.
+	//
+	// The method is called just before a cached response
+	// is returned from the cache.
+	fresh(resp *http.Response) freshness
+}
+
+// Storage represents the cache storage.
+//
+// A storage must be safe to use from multiple goroutines.
+type Storage interface {
+	// Store stores the given response.
+	//
+	// The method is called just after the response's body is
+	// closed, the value contains the full response including headers.
+	Store(ctx context.Context, key uint64, value []byte) error
+
+	// Load loads a response by its key.
+	//
+	// When the response is not found, the method returns a nil
+	// byteslice and a nil error.
+	//
+	// The method returns the full response, as stored by `Store()`.
+	Load(ctx context.Context, key uint64) ([]byte, error)
+}
+
+// Client represents an HTTP client.
+type Client interface {
+	// Do performs the given request.
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Option represents a cache option.
+type Option func(*Cache) error
+
+// WithStorage sets the storage to s.
+func WithStorage(s Storage) Option {
+	return func(c *Cache) error {
+		if s == nil {
+			return errors.New("antcache: storage must be non-nil")
+		}
+		c.storage = s
+		return nil
+	}
+}
+
+// WithLogger sets the logger to log.
+func WithLogger(log *log.Logger) Option {
+	return func(c *Cache) error {
+		if log == nil {
+			return errors.New("antcache: log must be non-nil")
+		}
+		c.log = log
+		return nil
+	}
+}
+
+// Cache implements an HTTP cache.
+type Cache struct {
+	storage  Storage
+	strategy strategy
+	client   Client
+	log      *log.Logger
+}
+
+// New returns a new cache with the given options.
+func New(c Client, opts ...Option) (*Cache, error) {
+	var cache = &Cache{
+		strategy: rfc7234{},
+		storage:  &memstore{},
+		client:   c,
+		log:      nil,
+	}
+
+	if c == nil {
+		return nil, errors.New("antcache: client must be non-nil")
+	}
+
+	for _, opt := range opts {
+		if err := opt(cache); err != nil {
+			return nil, err
+		}
+	}
+
+	return cache, nil
+}
+
+// Do performs the given request.
+//
+// The method initially checks if the request can be cached
+// if so, it will lookup a response that matches the request
+// and return it if it's fresh, or was validated.
+//
+// When the request is not cacheable, the method simply calls
+// the underlying client with the request and never caches the response.
+//
+// When a response is not found, the method calls the underlying client
+// and if the response can be stored, it will store it when its body
+// is closed, if the body is not closed, the response is never cached.
+//
+// When storage errors occure while loading/storing a response the method
+// logs the errors if a logger is set and no errors are returned, the method
+// will simply fallback to the underlying client on storage errors.
+func (c *Cache) Do(req *http.Request) (*http.Response, error) {
+	if !c.strategy.cache(req) {
+		return c.client.Do(req)
+	}
+
+	var key = keyof(req)
+
+	if resp, ok := c.load(key, req); ok {
+		return resp, nil
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.strategy.store(resp) {
+		c.store(key, resp)
+	}
+
+	return resp, nil
+}
+
+// Load loads a response from the cache storage for req.
+//
+// The method attempts to load a cached response for req, if a response
+// is found in the storage and is fresh the method returns the response
+// along with `ok=true`.
+//
+// If any storage related errors occur, the method simply logs the errors
+// and returns a nil response with ok=false, if an error logger is not
+// defined on the cache, no logs are produced.
+//
+// If the response is stale, the method will send a validation request
+// and if the response is still fresh, the method returns it and updates
+// the cached response.
+func (c *Cache) load(key uint64, req *http.Request) (*http.Response, bool) {
+	var ctx = req.Context()
+
+	buf, err := c.storage.Load(ctx, key)
+	if err != nil {
+		c.error("antcache: storage load %d - %s", key, err)
+		return nil, false
+	}
+
+	b := bytes.NewBuffer(buf)
+	r := bufio.NewReader(b)
+
+	resp, err := http.ReadResponse(r, req)
+	if err != nil {
+		c.error("antcache: read cached response - %s", err)
+		return nil, false
+	}
+
+	switch c.strategy.fresh(resp) {
+	case fresh:
+		return resp, true
+
+	case stale:
+		return c.verify(ctx, key, resp)
+	}
+
+	return nil, false
+}
+
+// Verify verifies that the given response is still valid.
+func (c *Cache) verify(ctx context.Context, key uint64, resp *http.Response) (*http.Response, bool) {
+	var req = resp.Request.Clone(ctx)
+	var hdr = resp.Header
+
+	if etag := hdr.Get("ETag"); etag != "" {
+		req.Header.Set("If-None-Match", etag)
+	}
+
+	if t := hdr.Get("Last-Modified"); t != "" {
+		req.Header.Set("If-Modified-Since", t)
+	}
+
+	newresp, err := c.client.Do(req)
+	if err != nil {
+		c.error("antcache: validate %s - %s", req.URL, err)
+		return nil, false
+	}
+
+	if newresp.StatusCode == 304 {
+		return resp, true
+	}
+
+	if c.strategy.store(resp) {
+		c.store(key, newresp)
+		return resp, true
+	}
+
+	return nil, false
+}
+
+// Store stores the given response.
+//
+// The method overwrites the response's body with a readcloser
+// that will write the response to the storage when it is closed.
+//
+// If the response body is not closed, the response is never
+// stored in the cache.
+func (c *Cache) store(key uint64, resp *http.Response) {
+	rc := resp.Body
+
+	resp.Body = &cachereader{
+		resp:  resp,
+		key:   key,
+		rc:    rc,
+		buf:   &bytes.Buffer{},
+		once:  &sync.Once{},
+		ctx:   resp.Request.Context(),
+		store: c.storage.Store,
+		log:   c.error,
+	}
+
+	return
+}
+
+// Error logs an error with msg and args.
+func (c *Cache) error(msg string, args ...interface{}) {
+	if c.log != nil {
+		c.log.Printf(msg, args...)
+	}
+}

--- a/antcache/httpcache_test.go
+++ b/antcache/httpcache_test.go
@@ -1,0 +1,5 @@
+package antcache
+
+import "testing"
+
+func TestCache(t *testing.T) {}

--- a/antcache/memstore.go
+++ b/antcache/memstore.go
@@ -1,0 +1,25 @@
+package antcache
+
+import (
+	"context"
+	"sync"
+)
+
+// Memstore implements an in-memory store.
+type memstore struct {
+	c sync.Map
+}
+
+// Store implementation.
+func (m *memstore) Store(ctx context.Context, key uint64, value []byte) error {
+	m.c.Store(key, value)
+	return nil
+}
+
+// Load implementation.
+func (m *memstore) Load(ctx context.Context, key uint64) ([]byte, error) {
+	if v, ok := m.c.Load(key); ok {
+		return v.([]byte), nil
+	}
+	return nil, nil
+}

--- a/antcache/memstore_test.go
+++ b/antcache/memstore_test.go
@@ -1,0 +1,33 @@
+package antcache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemstore(t *testing.T) {
+	t.Run("store, load", func(t *testing.T) {
+		var ctx = context.Background()
+		var assert = require.New(t)
+		var mem = &memstore{}
+
+		err := mem.Store(ctx, uint64(1), []byte("v"))
+		assert.NoError(err)
+
+		v, err := mem.Load(ctx, uint64(1))
+		assert.NoError(err)
+		assert.Equal([]byte("v"), v)
+	})
+
+	t.Run("load not found", func(t *testing.T) {
+		var ctx = context.Background()
+		var assert = require.New(t)
+		var mem = &memstore{}
+
+		v, err := mem.Load(ctx, uint64(1))
+		assert.NoError(err)
+		assert.Nil(v)
+	})
+}

--- a/antcache/rfc7234.go
+++ b/antcache/rfc7234.go
@@ -1,0 +1,154 @@
+package antcache
+
+import (
+	"net/http"
+	"time"
+)
+
+// RFC7234 uses an RFC7234 caching implementation.
+//
+// Note that requests with content-range, range and authorization
+// headers are never cached, some directives are also not
+// implemented and are skipped ("immutable", "stale-if-error").
+func RFC7234() Option {
+	return func(c *Cache) error {
+		c.strategy = rfc7234{}
+		return nil
+	}
+}
+
+// RFC7234 implements the standard cache strategy.
+//
+// https://tools.ietf.org/html/rfc7234
+type rfc7234 struct{}
+
+// Cache implementation.
+//
+// The method returns true if the request may use a cached
+// response, or if it allows caching.
+func (rfc7234) cache(req *http.Request) bool {
+	return (req.Method == "GET" || req.Method == "HEAD") && !nostore(req.Header)
+}
+
+// Store implementation.
+//
+// https://tools.ietf.org/html/rfc7234#section-3
+func (rfc7234) store(resp *http.Response) bool {
+	var req = resp.Request
+
+	// The request method is cacheable.
+	switch req.Method {
+	case "GET":
+	case "HEAD":
+	default:
+		return false
+	}
+
+	// The response status code is cacheable.
+	switch resp.StatusCode {
+	case 200, 203, 204, 206:
+	case 300, 301:
+	case 404, 405, 410, 414:
+	case 501:
+	default:
+		return false
+	}
+
+	// Parse request and response directives.
+	var (
+		reqd = directivesFrom(req.Header)
+		resd = directivesFrom(resp.Header)
+	)
+
+	// the "no-store" cache directive (see Section 5.2) does not appear
+	// in request or response header fields.
+	if reqd.has("no-store") || resd.has("no-store") {
+		return false
+	}
+
+	// ensure that the date header is set and
+	// there's explicit expiry max-age/expires.
+	if d, ok := date(resp.Header); ok {
+		if maxage, ok := resd.duration("max-age"); ok {
+			return maxage > 0
+		}
+
+		if exp, ok := expires(resp.Header); ok {
+			return exp.Sub(d) > 0
+		}
+	}
+
+	// The response has an explicit "lifetime" duration.
+	return false
+}
+
+// Fresh implementation.
+//
+// https://tools.ietf.org/html/rfc7234#section-4
+func (rfc7234) fresh(resp *http.Response) freshness {
+	var req = resp.Request
+
+	// selecting header fields nominated by the stored response (if any)
+	// match those presented (see Section 4.1).
+	if !matches(req, resp) {
+		return transparent
+	}
+
+	// Parse request and response directives.
+	var (
+		reqd = directivesFrom(req.Header)
+		resd = directivesFrom(resp.Header)
+	)
+
+	// the presented request does not contain the no-cache pragma
+	// (Section 5.4), nor the no-cache cache directive (Section 5.2.1),
+	// unless the stored response is successfully validated (Section 4.3).
+	//
+	// the stored response does not contain the no-cache cache directive
+	// (Section 5.2.2.2), unless it is successfully validated (Section 4.3)
+	if reqd.has("no-cache") || resd.has("no-cache") {
+		return stale
+	}
+
+	// When only-if-cached is set, always return fresh.
+	if reqd.has("only-if-cached") {
+		return fresh
+	}
+
+	// the stored response is either fresh (see Section 4.2).
+	if d, ok := date(resp.Header); ok {
+		var age = time.Since(d)
+		var lifetime time.Duration
+
+		if maxage, ok := resd.duration("max-age"); ok {
+			lifetime = maxage
+		} else if exp, ok := expires(resp.Header); ok {
+			lifetime = exp.Sub(d)
+		}
+
+		if maxage, ok := reqd.duration("max-age"); ok {
+			lifetime = maxage
+		}
+
+		if minfresh, ok := reqd.duration("min-fresh"); ok {
+			age += minfresh
+		}
+
+		if reqd.has("max-stale") {
+			ms, ok := reqd.duration("max-stale")
+
+			if !ok {
+				return fresh
+			}
+
+			age -= ms
+		}
+
+		if lifetime > age {
+			return fresh
+		}
+	}
+
+	// validate (see Section 4.3).
+	return stale
+}

--- a/antcache/rfc7234_test.go
+++ b/antcache/rfc7234_test.go
@@ -1,0 +1,332 @@
+package antcache
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRFC7234(t *testing.T) {
+	t.Run("store", func(t *testing.T) {
+		var now = time.Now().UTC()
+		var cases = []struct {
+			title string
+			resp  *http.Response
+			store bool
+		}{
+			{
+				title: "GET",
+				resp: &http.Response{
+					StatusCode: 200,
+					Header: http.Header{
+						"Date":          {now.Format(time.RFC1123)},
+						"Cache-Control": {"max-age=5"},
+					},
+					Request: &http.Request{
+						Method: "GET",
+					},
+				},
+				store: true,
+			},
+			{
+				title: "HEAD",
+				resp: &http.Response{
+					StatusCode: 200,
+					Header: http.Header{
+						"Date":          {now.Format(time.RFC1123)},
+						"Cache-Control": {"max-age=5"},
+					},
+					Request: &http.Request{
+						Method: "HEAD",
+					},
+				},
+				store: true,
+			},
+			{
+				title: "POST",
+				resp: &http.Response{
+					StatusCode: 200,
+					Request: &http.Request{
+						Method: "POST",
+					},
+				},
+				store: false,
+			},
+			{
+				title: "GET 500",
+				resp: &http.Response{
+					StatusCode: 500,
+					Request: &http.Request{
+						Method: "GET",
+					},
+				},
+				store: false,
+			},
+			{
+				title: "GET request no-store",
+				resp: &http.Response{
+					StatusCode: 200,
+					Request: &http.Request{
+						Method: "GET",
+						Header: http.Header{
+							"Cache-Control": {"no-store"},
+						},
+					},
+				},
+				store: false,
+			},
+			{
+				title: "GET response no-store",
+				resp: &http.Response{
+					StatusCode: 200,
+					Header: http.Header{
+						"Cache-Control": {"no-store"},
+					},
+					Request: &http.Request{
+						Method: "GET",
+					},
+				},
+				store: false,
+			},
+			{
+				title: "GET response expired",
+				resp: &http.Response{
+					StatusCode: 200,
+					Header: http.Header{
+						"Date":    {now.Format(time.RFC1123)},
+						"Expires": {now.Add(-time.Minute).Format(time.RFC1123)},
+					},
+					Request: &http.Request{
+						Method: "GET",
+					},
+				},
+				store: false,
+			},
+			{
+				title: "GET response expires",
+				resp: &http.Response{
+					StatusCode: 200,
+					Header: http.Header{
+						"Date":    {now.Format(time.RFC1123)},
+						"Expires": {now.Add(time.Minute).Format(time.RFC1123)},
+					},
+					Request: &http.Request{
+						Method: "GET",
+					},
+				},
+				store: true,
+			},
+			{
+				title: "GET no explicit cache",
+				resp: &http.Response{
+					StatusCode: 200,
+					Header:     http.Header{},
+					Request: &http.Request{
+						Method: "GET",
+					},
+				},
+				store: false,
+			},
+		}
+
+		for _, c := range cases {
+			t.Run(c.title, func(t *testing.T) {
+				var assert = require.New(t)
+				var strategy = rfc7234{}
+
+				assert.Equal(c.store, strategy.store(c.resp))
+			})
+		}
+	})
+
+	t.Run("fresh", func(t *testing.T) {
+		var now = time.Now()
+		var cases = []struct {
+			title string
+			resp  *http.Response
+			fresh freshness
+		}{
+			{
+				title: "no-cache request",
+				resp: &http.Response{
+					Request: &http.Request{
+						Header: http.Header{
+							"Cache-Control": {"no-cache"},
+						},
+					},
+				},
+				fresh: stale,
+			},
+			{
+				title: "no-cache response",
+				resp: &http.Response{
+					Header: http.Header{
+						"Cache-Control": {"no-cache"},
+					},
+					Request: &http.Request{},
+				},
+				fresh: stale,
+			},
+			{
+				title: "vary mismatch",
+				resp: &http.Response{
+					Request: &http.Request{
+						Header: http.Header{
+							"Vary":            {"Accept-Language"},
+							"Accept-Language": {"en-US"},
+						},
+					},
+				},
+				fresh: transparent,
+			},
+			{
+				title: "stale",
+				resp: &http.Response{
+					Request: &http.Request{},
+				},
+				fresh: stale,
+			},
+			{
+				title: "only-if-cached response",
+				resp: &http.Response{
+					Request: &http.Request{
+						Header: http.Header{
+							"Cache-Control": {"only-if-cached"},
+						},
+					},
+				},
+				fresh: fresh,
+			},
+			{
+				title: "fresh max-age",
+				resp: &http.Response{
+					Request: &http.Request{},
+					Header: http.Header{
+						"Date":          {now.Format(time.RFC1123)},
+						"Cache-Control": {"max-age=5"},
+					},
+				},
+				fresh: fresh,
+			},
+			{
+				title: "zero max-age",
+				resp: &http.Response{
+					Request: &http.Request{},
+					Header: http.Header{
+						"Date":          {now.Format(time.RFC1123)},
+						"Cache-Control": {"max-age=0"},
+					},
+				},
+				fresh: stale,
+			},
+			{
+				title: "fresh expires",
+				resp: &http.Response{
+					Request: &http.Request{},
+					Header: http.Header{
+						"Date":    {now.Format(time.RFC1123)},
+						"Expires": {now.Add(time.Minute).Format(time.RFC1123)},
+					},
+				},
+				fresh: fresh,
+			},
+			{
+				title: "date == expires",
+				resp: &http.Response{
+					Request: &http.Request{},
+					Header: http.Header{
+						"Date":    {now.Format(time.RFC1123)},
+						"Expires": {now.Format(time.RFC1123)},
+					},
+				},
+				fresh: stale,
+			},
+			{
+				title: "request max-age",
+				resp: &http.Response{
+					Request: &http.Request{
+						Header: http.Header{
+							"Cache-Control": {"max-age=5"},
+						},
+					},
+					Header: http.Header{
+						"Date": {now.Format(time.RFC1123)},
+					},
+				},
+				fresh: fresh,
+			},
+			{
+				title: "request zero max-age",
+				resp: &http.Response{
+					Request: &http.Request{
+						Header: http.Header{
+							"Cache-Control": {"max-age=0"},
+						},
+					},
+					Header: http.Header{
+						"Date": {now.Format(time.RFC1123)},
+					},
+				},
+				fresh: stale,
+			},
+			{
+				title: "request min-fresh",
+				resp: &http.Response{
+					Request: &http.Request{
+						Header: http.Header{
+							"Cache-Control": {"min-fresh=3"},
+						},
+					},
+					Header: http.Header{
+						"Date":          {now.Format(time.RFC1123)},
+						"Cache-Control": {"max-age=5"},
+					},
+				},
+				fresh: fresh,
+			},
+			{
+				title: "request min-fresh reached",
+				resp: &http.Response{
+					Request: &http.Request{
+						Header: http.Header{
+							"Cache-Control": {"min-fresh=5"},
+						},
+					},
+					Header: http.Header{
+						"Date":          {now.Format(time.RFC1123)},
+						"Cache-Control": {"max-age=5"},
+					},
+				},
+				fresh: stale,
+			},
+			{
+				title: "max-stale",
+				resp: &http.Response{
+					Request: &http.Request{
+						Header: http.Header{
+							"Cache-Control": {"max-stale"},
+						},
+					},
+					Header: http.Header{
+						"Date": {now.Format(time.RFC1123)},
+					},
+				},
+				fresh: fresh,
+			},
+		}
+
+		for _, c := range cases {
+			t.Run(c.title, func(t *testing.T) {
+				var assert = require.New(t)
+				var strategy = rfc7234{}
+
+				expect := c.fresh
+				got := strategy.fresh(c.resp)
+
+				assert.Equal(expect.String(), got.String())
+			})
+		}
+	})
+}

--- a/antcache/utils.go
+++ b/antcache/utils.go
@@ -1,0 +1,81 @@
+package antcache
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spaolacci/murmur3"
+)
+
+// Keyof returns a cache key of req.
+func keyof(req *http.Request) uint64 {
+	return murmur3.Sum64([]byte(
+		req.Method + ":" + req.URL.String(),
+	))
+}
+
+// Matches ensures that the given request and response match.
+//
+// https://tools.ietf.org/html/rfc7234#section-4.1
+func matches(req *http.Request, resp *http.Response) bool {
+	var vary = req.Header.Get("Vary")
+
+	for _, h := range split(vary, ",") {
+		if key := http.CanonicalHeaderKey(h); key != "" {
+			if req.Header.Get(key) != resp.Header.Get(key) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// Nostore returns true if no-store is set.
+func nostore(h http.Header) bool {
+	var c = h.Get("Cache-Control")
+
+	for _, v := range split(c, ",") {
+		if v == "no-store" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Expires returns the expires timestamp.
+//
+// When expires does not exist or is zero, ok is false.
+func expires(h http.Header) (expires time.Time, ok bool) {
+	if v := h.Get("Expires"); v != "" {
+		t, err := time.Parse(time.RFC1123, v)
+		expires, ok = t, (err == nil && !t.IsZero())
+	}
+	return
+}
+
+// Date returns the date timestamp.
+//
+// When date does not exist or is zero, ok is false.
+func date(h http.Header) (date time.Time, ok bool) {
+	if v := h.Get("Date"); v != "" {
+		t, err := time.Parse(time.RFC1123, v)
+		date, ok = t, (err == nil && !t.IsZero())
+	}
+	return
+}
+
+// Split splits the given str by sep.
+//
+// The method omits any empty values and normalizes
+// the values by lowercasing them.
+func split(str, sep string) (ret []string) {
+	for _, v := range strings.Split(str, sep) {
+		if v := strings.TrimSpace(v); v != "" {
+			ret = append(ret, strings.ToLower(v))
+		}
+	}
+	return
+}

--- a/antcache/utils_test.go
+++ b/antcache/utils_test.go
@@ -1,0 +1,5 @@
+package antcache
+
+import "testing"
+
+func TestUtils(t *testing.T) {}

--- a/disk.go
+++ b/disk.go
@@ -1,0 +1,1 @@
+package ant

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,11 @@ go 1.14
 require (
 	github.com/andybalholm/cascadia v1.2.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-errors/errors v1.1.1
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/mafredri/cdp v0.29.2
 	github.com/segmentio/agecache v0.0.0-20200415044159-6857a7326986
-	github.com/spaolacci/murmur3 v1.1.0 // indirect
+	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.6.1
 	github.com/temoto/robotstxt v1.1.1
 	github.com/tidwall/match v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-errors/errors v1.1.1 h1:ljK/pL5ltg3qoN+OtN6yCv9HWSfMwxSx90GJCZQxYNg=
+github.com/go-errors/errors v1.1.1/go.mod h1:psDX2osz5VnTOnFWbDeWwS7yejl+uV3FEWEp4lssFEs=
 github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=


### PR DESCRIPTION
Initial antcache that implements a private HTTP cache based on RFC7234.

Basic usage is to just initialize a cache, which in turn implements
an ant.Client and pass it to the fetcher:

```go
client, err := antcache.New(ant.DefaultClient)
if err != nil {
  log.Printf("new cache: %s", err)
}

eng, err := ant.NewEngine(ant.EngineConfig{
  Fetcher: &ant.Fetcher{
    Client: client,
  },
})
```

Since some websites never implement caching and typically require lots of
validations from clients, there's also an aggressive cache which fits
the crawlers use-case well, think daily crawls:

```go
client, err := antcache.New(
  ant.DefaultClient,
  antcache.Aggressive(24*time.Hour),
)
if err != nil {
  log.Printf("new cache: %s", err)
}

eng, err := ant.NewEngine(ant.EngineConfig{
  Fetcher: &ant.Fetcher{
    Client: client,
  },
})
```

You can also persist the cache into some directory:

```go
disk, err := antcache.Open("/tmp")
if err != nil {
  log.Printf("open disk: %s", err)
}

// We wait here in case there a lot of files in the directory
// the diskstore maintains a cache of entries to speed up `Load()`s.
//
// The disk cache also removes entries asynchronously when they expire.
if err := disk.Wait(ctx); err != nil {
  log.Printf("disk wait: %s", err)
}

client, err := antcache.New(
  ant.DefaultClient,
  antcache.WithStorage(disk),
)
```
