### PR TITLE
Fix import in example for antcdp

### DIFF
--- a/_examples/cdp/main.go
+++ b/_examples/cdp/main.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/yields/ant"
-	"github.com/yields/ant/exp/antcdp"
+	"github.com/yields/ant/antcdp"
 )
 
 func main() {


### PR DESCRIPTION
The import in the example for antcdp was incorrect (probably outdated), and gave the following error:

```
go get: module github.com/yields/ant@upgrade found (v0.0.0-20210325225620-7fef9fdab5a8), but does not contain package github.com/yields/ant/exp/antcdp
```